### PR TITLE
Fix template add filter in barcode inventory list

### DIFF
--- a/trf_core/templates/trf_core/barcode_inventory_list.html
+++ b/trf_core/templates/trf_core/barcode_inventory_list.html
@@ -50,10 +50,12 @@
                             <td>{{ inventory.created_by.username }}</td>
                             <td>{{ inventory.created_at|date:"Y-m-d H:i" }}</td>
                             <td>
-                                {% with total_count=inventory.end_number|add:-inventory.start_number|add:1 %}
+                                {% with difference=inventory.end_number|add:"-inventory.start_number" %}
+                                    {% with total_count=difference|add:"1" %}
                                     <span class="badge bg-{% if inventory.available_count > 0 %}success{% else %}danger{% endif %}">
                                         {{ inventory.available_count }} / {{ total_count }}
                                     </span>
+                                {% endwith %}
                                 {% endwith %}
                             </td>
                             <td>


### PR DESCRIPTION
This PR fixes a template syntax error in the barcode inventory list template where the add filter was being used incorrectly. The changes:

1. Split the calculation into two steps using nested with blocks
2. First calculate the difference between end_number and start_number
3. Then add 1 to get the total count

This resolves the TemplateSyntaxError: add requires 2 arguments error.