### PR TITLE
Fix barcode expiry date handling during inventory creation

### DIFF
--- a/trf_core/models.py
+++ b/trf_core/models.py
@@ -108,7 +108,7 @@ class Barcode(models.Model):
             self.barcode_image.save(f'barcode_{self.barcode_number}.png',
                                   File(buffer), save=False)
         
-        if not self.expiry_date:
+        if not self.expiry_date and self.trf:
             self.expiry_date = self.trf.expiry_date
             
         super().save(*args, **kwargs)


### PR DESCRIPTION
This PR fixes the error `NoneType object has no attribute expiry_date` that occurs during barcode inventory creation.

The issue was that the Barcode model was trying to get the expiry_date from the TRF even when no TRF was associated with the barcode. This has been fixed by only getting the expiry_date from TRF if a TRF exists.

Changes:
- Modified the Barcode model save method to check if TRF exists before trying to access its expiry_date

This allows barcode inventory creation to work without requiring an expiry date, which will be set later when the barcode is assigned to a TRF.