### PR TITLE
Simplify barcode assignment and add custom expiry date option

### DIFF
--- a/trf_core/templates/trf_core/trf_detail.html
+++ b/trf_core/templates/trf_core/trf_detail.html
@@ -22,14 +22,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const formData = new FormData(form);
         const data = {
             barcode_number: formData.get('barcode_number'),
-            trf_id: formData.get('trf_id'),
-            tube_data: {
-                sample_type: formData.get('sample_type'),
-                volume: formData.get('volume'),
-                collection_date: formData.get('collection_date'),
-                notes: formData.get('notes')
-            }
+            trf_id: formData.get('trf_id')
         };
+
+        // Add expiry date if using custom expiry
+        if (!formData.get('use_default_expiry')) {
+            data.expiry_date = formData.get('expiry_date');
+        }
 
         try {
             const response = await fetch(form.action, {
@@ -56,29 +55,17 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
-    // Handle barcode scanner input
-    let lastScan = '';
-    let scanTimer = null;
+    // Handle custom expiry checkbox
+    const useDefaultExpiry = document.getElementById('useDefaultExpiry');
+    const customExpiryDiv = document.getElementById('customExpiryDiv');
+    const customExpiry = document.getElementById('customExpiry');
 
-    barcodeInput.addEventListener('keypress', function(e) {
-        // If Enter is pressed and there's a value, submit the form
-        if (e.key === 'Enter' && this.value) {
-            e.preventDefault();
-            form.dispatchEvent(new Event('submit'));
+    useDefaultExpiry.addEventListener('change', function() {
+        customExpiryDiv.style.display = this.checked ? 'none' : 'block';
+        if (!this.checked) {
+            customExpiry.focus();
         }
     });
-
-    barcodeInput.addEventListener('input', function(e) {
-        clearTimeout(scanTimer);
-        lastScan = this.value;
-        
-        // Set a timer to detect end of barcode scanner input
-        scanTimer = setTimeout(() => {
-            if (lastScan === this.value && this.value) {
-                // Auto-submit if the value hasn't changed for 100ms
-                form.dispatchEvent(new Event('submit'));
-            }
-        }, 100);
     });
 });
 </script>
@@ -218,20 +205,16 @@ document.addEventListener('DOMContentLoaded', function() {
                                                    placeholder="Scan barcode or enter number" autofocus>
                                         </div>
                                         <div class="mb-3">
-                                            <label for="sampleType" class="form-label">Sample Type</label>
-                                            <input type="text" class="form-control" id="sampleType" name="sample_type">
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="checkbox" id="useDefaultExpiry" name="use_default_expiry" checked>
+                                                <label class="form-check-label" for="useDefaultExpiry">
+                                                    Use TRF expiry date ({{ trf.expiry_date|date:"Y-m-d" }})
+                                                </label>
+                                            </div>
                                         </div>
-                                        <div class="mb-3">
-                                            <label for="volume" class="form-label">Volume</label>
-                                            <input type="text" class="form-control" id="volume" name="volume">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label for="collectionDate" class="form-label">Collection Date</label>
-                                            <input type="date" class="form-control" id="collectionDate" name="collection_date">
-                                        </div>
-                                        <div class="mb-3">
-                                            <label for="notes" class="form-label">Notes</label>
-                                            <textarea class="form-control" id="notes" name="notes" rows="2"></textarea>
+                                        <div class="mb-3" id="customExpiryDiv" style="display: none;">
+                                            <label for="customExpiry" class="form-label">Custom Expiry Date</label>
+                                            <input type="date" class="form-control" id="customExpiry" name="expiry_date">
                                         </div>
                                     </form>
                                 </div>

--- a/trf_core/views.py
+++ b/trf_core/views.py
@@ -205,7 +205,20 @@ def process_scanned_barcode(request):
             barcode.is_available = False
             barcode.assigned_at = timezone.now()
             barcode.assigned_by = request.user
-            barcode.tube_data = tube_data
+            
+            # Handle expiry date
+            expiry_date = data.get('expiry_date')
+            if expiry_date:
+                try:
+                    barcode.expiry_date = datetime.strptime(expiry_date, '%Y-%m-%d').date()
+                except ValueError:
+                    return JsonResponse({
+                        'success': False,
+                        'message': 'Invalid expiry date format'
+                    })
+            else:
+                barcode.expiry_date = trf.expiry_date
+            
             barcode.save()
 
             return JsonResponse({


### PR DESCRIPTION
This PR simplifies the barcode assignment process and adds a custom expiry date option:

1. Simplified barcode assignment:
   - Removed auto-submit functionality
   - Removed unnecessary fields (sample type, volume, collection date, notes)
   - Focused on just barcode number and expiry date

2. Added custom expiry date option:
   - Added checkbox to toggle between TRF expiry date and custom expiry date
   - When unchecked, shows a date picker for custom expiry date
   - Shows the current TRF expiry date in the checkbox label
   - Automatically focuses the date picker when switching to custom expiry

These changes make the barcode assignment process simpler and more focused, while still allowing flexibility with expiry dates.