### PR TITLE
Allow external barcodes with flexible format

### DIFF
--- a/trf_core/templates/trf_core/barcode_scanner.html
+++ b/trf_core/templates/trf_core/barcode_scanner.html
@@ -81,6 +81,11 @@
                             <input type="datetime-local" class="form-control" id="collection_date">
                         </div>
                         <div class="mb-3">
+                            <label for="expiry_date" class="form-label">Custom Expiry Date (Optional)</label>
+                            <input type="date" class="form-control" id="expiry_date">
+                            <small class="text-muted">Leave empty to use TRF expiry date</small>
+                        </div>
+                        <div class="mb-3">
                             <label for="notes" class="form-label">Notes</label>
                             <textarea class="form-control" id="notes" rows="2"></textarea>
                         </div>
@@ -206,7 +211,8 @@
             body: JSON.stringify({
                 barcode_number: barcode,
                 trf_id: trfId,
-                tube_data: tubeData
+                tube_data: tubeData,
+                expiry_date: document.getElementById('expiry_date').value
             })
         })
         .then(response => response.json())
@@ -217,6 +223,7 @@
                 document.getElementById('barcode_input').value = '';
                 document.getElementById('volume').value = '';
                 document.getElementById('notes').value = '';
+                document.getElementById('expiry_date').value = '';
             }
         })
         .catch(error => {


### PR DESCRIPTION
This PR adds support for external barcodes with the following changes:

- Remove CT- format restriction to allow any barcode format
- Add validation for uniqueness and assignment
- Support custom expiry dates with fallback to TRF expiry
- Improve error messages for better user feedback

Validations:
- Barcode must not be empty
- Must be unique in the system
- Cannot be already assigned to another TRF
- Expiry date cannot be in the past